### PR TITLE
Made multiple languages behavior more consistent.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "google-translate-ext",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -127,7 +127,7 @@ function translateSelection(selection: vscode.Selection | vscode.Range): void {
 	}
 	if (typeof languages === "string") {
 		translate(selectedText, <vscode.Selection>selection, languages);
-	} else {
+	} else if (replaceText) {
 		const quickPick = vscode.window.createQuickPick();
 		quickPick.items = languages.sort().map((label: string) => ({ label }));
 		quickPick.placeholder = "Select a language...";
@@ -136,8 +136,11 @@ function translateSelection(selection: vscode.Selection | vscode.Range): void {
 			quickPick.dispose();
 		});
 		quickPick.onDidHide(() => quickPick.dispose());
-
 		quickPick.show();
+	} else {
+		languages.forEach((language: string) => {
+			translate(selectedText, <vscode.Selection>selection, language);
+		});
 	}
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -128,15 +128,19 @@ function translateSelection(selection: vscode.Selection | vscode.Range): void {
 	if (typeof languages === "string") {
 		translate(selectedText, <vscode.Selection>selection, languages);
 	} else if (replaceText) {
-		const quickPick = vscode.window.createQuickPick();
-		quickPick.items = languages.sort().map((label: string) => ({ label }));
-		quickPick.placeholder = "Select a language...";
-		quickPick.onDidAccept(() => {
-			translate(selectedText, <vscode.Selection>selection, quickPick.selectedItems [0].label);
-			quickPick.dispose();
-		});
-		quickPick.onDidHide(() => quickPick.dispose());
-		quickPick.show();
+		if (languages.length > 1) {
+			const quickPick = vscode.window.createQuickPick();
+			quickPick.items = languages.sort().map((label: string) => ({ label }));
+			quickPick.placeholder = "Select a language...";
+			quickPick.onDidAccept(() => {
+				translate(selectedText, <vscode.Selection>selection, quickPick.selectedItems [0].label);
+				quickPick.dispose();
+			});
+			quickPick.onDidHide(() => quickPick.dispose());
+			quickPick.show();
+		} else {
+			translate(selectedText, <vscode.Selection>selection, languages[0]);
+		}
 	} else {
 		languages.forEach((language: string) => {
 			translate(selectedText, <vscode.Selection>selection, language);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -128,13 +128,16 @@ function translateSelection(selection: vscode.Selection | vscode.Range): void {
 	if (typeof languages === "string") {
 		translate(selectedText, <vscode.Selection>selection, languages);
 	} else {
-		if (replaceText) {
-			translate(selectedText, <vscode.Selection>selection, languages[0]);
-		} else {
-			languages.forEach((language: string) => {
-				translate(selectedText, <vscode.Selection>selection, language);
-			});
-		}
+		const quickPick = vscode.window.createQuickPick();
+		quickPick.items = languages.sort().map((label: string) => ({ label }));
+		quickPick.placeholder = "Select a language...";
+		quickPick.onDidAccept(() => {
+			translate(selectedText, <vscode.Selection>selection, quickPick.selectedItems [0].label);
+			quickPick.dispose();
+		});
+		quickPick.onDidHide(() => quickPick.dispose());
+
+		quickPick.show();
 	}
 }
 


### PR DESCRIPTION
Previously, when multiple languages were specified in VSCode settings, the only change would be that multiple information messages would appear, each with the selected text translated into one of the specified languages. If the user wanted to replace the existing text instead, the extension would only use the first one. 

With this change, a drop down will appear prompting the user to pick one of the languages they specified in settings. I think this behavior is more consistent, and a lot more useful.